### PR TITLE
fix: readme typos

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,13 +2,17 @@ name: Lint
 
 on: pull_request
 
-permissions: read-all
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  pull-requests: read
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v1.1.2
+        uses: trunk-io/trunk-action@65228585e2c6128315f0f2d5190e2eae7f5c32c6 # v1.1.10

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -2,7 +2,8 @@
 *logs
 *actions
 *notifications
+*tools
 plugins
 user_trunk.yaml
 user.yaml
-tools
+tmp

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,24 +1,24 @@
 version: 0.1
 cli:
-  version: 1.13.0
+  version: 1.20.1
 plugins:
   sources:
     - id: trunk
-      ref: v1.0.0
+      ref: v1.4.4
       uri: https://github.com/trunk-io/plugins
 lint:
   enabled:
-    - actionlint@1.6.25
-    - checkov@2.3.347
+    - actionlint@1.6.27
+    - checkov@3.2.31
     - git-diff-check
-    - markdownlint@0.35.0
-    - prettier@3.0.0
-    - terrascan@1.18.2
-    - tflint@0.47.0
-    - tfsec@1.28.1
-    - trivy@0.43.1
-    - trufflehog@3.45.2
-    - yamllint@1.32.0
+    - markdownlint@0.39.0
+    - prettier@3.2.5
+    - terrascan@1.18.12
+    - tflint@0.50.3
+    - tfsec@1.28.5
+    - trivy@0.49.1
+    - trufflehog@3.68.4
+    - yamllint@1.35.1
   ignore:
     - linters: [markdownlint]
       paths:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # terraform-secrets-helper [![Latest Release](https://img.shields.io/github/release/masterpointio/terraform-secrets-helper.svg)](https://github.com/masterpointio/terraform-secrets-helper/releases/latest)
 
-This Terraform module provides a standard and extensible way of managing secrets from different sources, making them accessible through local.secrets. It's designed with the aim of creating an abstract interface for dealing with secrets in Terraform, regardless of the source of these secrets.
+This Terraform module provides a standard and extensible way of managing secrets from different sources, making them accessible through `local.secrets["<SECRET_NAME>"]`. It's designed to create an abstract interface for dealing with secrets in Terraform, regardless of the source of these secrets.
 
 Our initial version is built to handle [SOPS secrets](https://github.com/getsops/sops), but it is designed in a way that it can be easily extended to support other secret providers like AWS SSM Parameter Store, Vault, and more in the future.
 
@@ -15,7 +15,7 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 Copy `exports/secrets.sops.tf` to your project by running the following command:
 
 ```sh
-curl -sL https://raw.githubusercontent.com/masterpointio/terraform-secrets-helper/main/exports/exports/secrets.sops.tf -o exports/secrets.sops.tf
+curl -sL https://raw.githubusercontent.com/masterpointio/terraform-secrets-helper/main/exports/secrets.sops.tf -o secrets.sops.tf
 ```
 
 The mixin incorporates the invocation of this module, so you simply need to configure the required `secret_mapping` variable and then reference it within your code.
@@ -28,7 +28,6 @@ secret_mapping = [{
   file = "test.yaml"
   type = "sops"
 }]
-
 
 output "db_password" {
   value     = jsonencode(local.secrets["db_password"])


### PR DESCRIPTION
## what

- Fix the invalid `curl` command in the example.
- Trunk upgrade.

## why

- This is an important init step.

## references

- N/A
