### PR TITLE
feat: use sops secret mapping type by default

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f #v4.1.3
+        with:
+          release-type: terraform-module

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -1,0 +1,34 @@
+name: Trunk Upgrade
+
+on:
+  schedule:
+    # On the first day of every month @ 8am
+    - cron: 0 8 1 * *
+  workflow_dispatch: {}
+
+permissions: read-all
+
+jobs:
+  trunk-upgrade:
+    runs-on: ubuntu-latest
+    permissions:
+      # For trunk to create PRs
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
+
+      - name: Create Token for MasterpointBot App
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
+        id: generate-token
+        with:
+          app_id: ${{ secrets.MP_BOT_APP_ID }}
+          private_key: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}
+
+      - name: Upgrade
+        uses: trunk-io/trunk-action/upgrade@86b68ffae610a05105e90b1f52ad8c549ef482c2 #v1.1.16
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          reviewers: "@masterpointio/masterpoint-internal"
+          prefix: "chore: "

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,23 +1,23 @@
 version: 0.1
 cli:
-  version: 1.20.1
+  version: 1.22.3
 plugins:
   sources:
     - id: trunk
-      ref: v1.4.4
+      ref: v1.6.2
       uri: https://github.com/trunk-io/plugins
 lint:
   enabled:
-    - actionlint@1.6.27
-    - checkov@3.2.31
+    - terrascan@1.19.1
+    - actionlint@1.7.1
+    - checkov@3.2.236
     - git-diff-check
-    - markdownlint@0.39.0
-    - prettier@3.2.5
-    - terrascan@1.18.12
-    - tflint@0.50.3
-    - tfsec@1.28.5
-    - trivy@0.49.1
-    - trufflehog@3.68.4
+    - markdownlint@0.41.0
+    - prettier@3.3.3
+    - tflint@0.53.0
+    - tfsec@1.28.10
+    - trivy@0.54.1
+    - trufflehog@3.81.9
     - yamllint@1.35.1
   ignore:
     - linters: [markdownlint]
@@ -30,7 +30,7 @@ lint:
         # Missing support for TF 1.3.0 `optional` with the second argument (the attribute default value)
         # https://github.com/tenable/terrascan/issues/1331
         - variables.tf
-        - exports/secrets.sops.tf
+        - "**/secrets.sops.tf"
 
 runtimes:
   enabled:

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ No modules.
 
 ## Inputs
 
-| Name           | Description                                                                                                                              | Type                                                                                        | Default | Required |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------- | :------: |
-| secret_mapping | The list of secret mappings the application will need. This creates secret values for the component to consume at `local.secrets[name]`. | `list(object({ name = string type = string path = optional(string, null) file = string }))` | `[]`    |    no    |
+| Name           | Description                                                                                                                              | Type                                                                                                          | Default | Required |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------- | :------: |
+| secret_mapping | The list of secret mappings the application will need. This creates secret values for the component to consume at `local.secrets[name]`. | `list(object({ name = string type = optional(string, "sops") path = optional(string, null) file = string }))` | `[]`    |    no    |
 
 ## Outputs
 

--- a/examples/complete/secrets.sops.tf
+++ b/examples/complete/secrets.sops.tf
@@ -1,7 +1,5 @@
 module "secrets" {
-  # checkov:skip=CKV_TF_1: For now we use Terraform registry source, not git. If switching to git, we should use a commit hash.
-  source         = "masterpointio/helper/secrets"
-  version        = "0.2.0"
+  source         = "../../"
   secret_mapping = var.secret_mapping
 }
 

--- a/examples/complete/test.auto.tfvars
+++ b/examples/complete/test.auto.tfvars
@@ -1,5 +1,4 @@
 secret_mapping = [{
   name = "db_password"
   file = "test.yaml"
-  type = "sops"
 }]

--- a/exports/secrets.sops.tf
+++ b/exports/secrets.sops.tf
@@ -1,7 +1,7 @@
 module "secrets" {
   # checkov:skip=CKV_TF_1: For now we use Terraform registry source, not git. If switching to git, we should use a commit hash.
   source         = "masterpointio/helper/secrets"
-  version        = "0.2.0"
+  version        = "0.3.0"
   secret_mapping = var.secret_mapping
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "secret_mapping" {
   type = list(object({
     name = string
-    type = string
+    type = optional(string, "sops")
     path = optional(string, null)
     file = string
   }))


### PR DESCRIPTION
## what

- Add the `sops` mapping type as a default fallback to avoid setting it for each key in the file.
- Updates trunk + GHA workflows.

## why

Since we currently use `sops` only (and will likely continue to do so even if we add support for other types), this will reduce repeating code.

## references

- N/A