### PR TITLE
feat: AWS SSM Parameter Store

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,11 +23,34 @@ locals {
     mapping.name => lookup(local.sops_yamls[mapping.file], mapping.name, null)
   }
 
-  # The final secrets for generic consumption
-  secrets = local.sops_secrets
+  # Filter out our ssm mappings
+  ssm_secret_mapping = [
+    for mapping in var.secret_mapping :
+    mapping if mapping.type == "ssm"
+  ]
+
+  # Collect the ssm paths we need to pull
+  ssm_paths = toset(distinct([
+    for mapping in local.ssm_secret_mapping :
+    mapping.path
+  ]))
+
+  # Create our ssm secret name to value map
+  ssm_secrets = {
+    for mapping in local.ssm_secret_mapping :
+    mapping.name => data.aws_ssm_parameter.ssm_secrets[mapping.path].value
+  }
+
+  # Merge the final ssm secrets + sops secrets for generic consumption in the component.
+  secrets = merge(local.sops_secrets, local.ssm_secrets)
 }
 
 data "sops_file" "sops_secrets" {
   for_each    = local.sops_files
   source_file = "${path.root}/${each.value}"
+}
+
+data "aws_ssm_parameter" "ssm_secrets" {
+  for_each = local.ssm_paths
+  name     = each.value
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "carlpett/sops"
       version = ">= 0.7"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
   }
 }


### PR DESCRIPTION
## what

- internal upstream of ssm support for secrets

## why

- allows some secrets to be managed in Parameter Store

## references

- [AWS SSM Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS Systems Manager Parameter Store support for secrets management, providing an additional source for secret configuration
  * Implemented unified secrets handling that merges secrets from multiple sources into a single consolidated map for simplified access
  * Enhanced infrastructure provisioning to automatically fetch and integrate parameters from both existing and new secret management sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->