### PR TITLE
fix: mock aws data sources in tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,8 +21,11 @@ jobs:
       matrix:
         tf: [tofu, terraform]
     steps:
+      # Only checkout for pull_request_target events (not for push to main)
+      # pull_request_target runs in the context of the base branch for security,
+      # so we must explicitly checkout the PR's head commit to test the actual changes
       - name: Checkout PR Head
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name != 'push'
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,12 @@ jobs:
       matrix:
         tf: [tofu, terraform]
     steps:
+      - name: Checkout PR Head
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - uses: masterpointio/github-action-tf-test@c3b619f3bca9e4f482b9e0fb3166ab3f02d9d54c # v1.0.0
         with:
           tf_type: ${{ matrix.tf }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,16 +21,7 @@ jobs:
       matrix:
         tf: [tofu, terraform]
     steps:
-      # Only checkout for pull_request_target events (not for push to main)
-      # pull_request_target runs in the context of the base branch for security,
-      # so we must explicitly checkout the PR's head commit to test the actual changes
-      - name: Checkout PR Head
-        if: github.event_name != 'push'
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - uses: masterpointio/github-action-tf-test@c3b619f3bca9e4f482b9e0fb3166ab3f02d9d54c # v1.0.0
+      - uses: masterpointio/github-action-tf-test@c1e41998f67925ac3f34e0bbcfcaa4a44d1f0cd9 # v1.0.1
         with:
           tf_type: ${{ matrix.tf }}
           aws_role_arn: ${{ vars.TF_TEST_AWS_ROLE_ARN }}

--- a/README.md
+++ b/README.md
@@ -51,12 +51,14 @@ While the current version is specific to SOPS, future mixins will support other 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 | <a name="requirement_sops"></a> [sops](#requirement\_sops) | >= 0.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 | <a name="provider_sops"></a> [sops](#provider\_sops) | >= 0.7 |
 
 ## Modules
@@ -67,6 +69,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_ssm_parameter.ssm_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [sops_file.sops_secrets](https://registry.terraform.io/providers/carlpett/sops/latest/docs/data-sources/file) | data source |
 
 ## Inputs

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -6,6 +6,14 @@ mock_provider "sops" {
   }
 }
 
+mock_provider "aws" {
+  mock_data "aws_ssm_parameter" {
+    defaults = {
+      value = "mock-ssm-value"
+    }
+  }
+}
+
 run "test_empty_secret_mapping" {
   command = plan
 

--- a/tests/outputs.tftest.hcl
+++ b/tests/outputs.tftest.hcl
@@ -6,6 +6,14 @@ mock_provider "sops" {
   }
 }
 
+mock_provider "aws" {
+  mock_data "aws_ssm_parameter" {
+    defaults = {
+      value = "mock-ssm-value"
+    }
+  }
+}
+
 run "test_output_structure_and_content" {
   command = plan
 


### PR DESCRIPTION
## what

- Added mock_provider blocks to both test files.
- Mocked `aws_ssm_parameter` data source to avoid AWS credential requirements.

## why

- Tests were failing with missing provider errors and AWS authentication issues:
```
│ Error: Invalid provider configuration
│ 
│ Provider "registry.opentofu.org/hashicorp/aws" requires explicit
│ configuration. Add a provider block to the root module and configure the
│ provider's required arguments as described in the provider documentation.
│ 
╵
tests/locals.tftest.hcl... fail
╷
│ Error: No valid credential sources found
│ 
│   with provider["registry.opentofu.org/hashicorp/aws"],
│   on provider["registry.opentofu.org/hashicorp/aws"] with no configuration line 1:
│   (source code not available)
│ 
│ Please see https://registry.terraform.io/providers/hashicorp/aws
│ for more information about providing credentials.
│ 
│ Error: failed to refresh cached credentials, no EC2 IMDS role found,
│ operation error ec2imds: GetMetadata, failed to get API token, operation
│ error ec2imds: getToken, http response error StatusCode: 400, request to
│ EC2 IMDS failed
│ 
╵
  run "test_empty_secret_mapping"... fail
  run "test_multiple_files_and_secrets"... skip
tests/outputs.tftest.hcl... fail
╷
│ Error: Invalid provider configuration
│ 
│ Provider "registry.opentofu.org/hashicorp/aws" requires explicit
│ configuration. Add a provider block to the root module and configure the
│ provider's required arguments as described in the provider documentation.
│ 
╵
╷
│ Error: No valid credential sources found
│ 
│   with provider["registry.opentofu.org/hashicorp/aws"],
│   on provider["registry.opentofu.org/hashicorp/aws"] with no configuration line 1:
│   (source code not available)
│ 
│ Please see https://registry.terraform.io/providers/hashicorp/aws
│ for more information about providing credentials.
│ 
│ Error: failed to refresh cached credentials, no EC2 IMDS role found,
│ operation error ec2imds: GetMetadata, failed to get API token, operation
│ error ec2imds: getToken, http response error StatusCode: 400, request to
│ EC2 IMDS failed
│ 
╵
  run "test_output_structure_and_content"... fail
  run "test_output_empty_secrets"... skip

Failure! 0 passed, 2 failed, 2 skipped.
Error: Process completed with exit code 1.
```

## references

- https://github.com/masterpointio/terraform-secrets-helper/actions/runs/18653720521/job/53177540605#step:2:237
