### PR TITLE
feat!: split into provider-specific sub-modules to allow excluding unused providers

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.4
+      ref: v1.7.5
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -20,15 +20,15 @@ lint:
     # Incompatible with some Terraform features: https://github.com/tenable/terrascan/issues/1331
     - terrascan
   enabled:
-    - renovate@43.46.3
+    - renovate@43.52.0
     - tofu@1.11.5
     - actionlint@1.7.11
     - checkov@3.2.506
     - git-diff-check
-    - markdownlint@0.47.0
+    - markdownlint@0.48.0
     - prettier@3.8.1
     - tflint@0.61.0
-    - trivy@0.69.0
+    - trivy@0.69.3
     - trufflehog@3.93.6
     - yamllint@1.38.0
   ignore:

--- a/README.md
+++ b/README.md
@@ -14,19 +14,59 @@ Our initial version is built to handle [SOPS secrets](https://github.com/getsops
 
 This module can be included as a child module, where needed, to fetch secrets and provide them in an abstract manner.
 
-## Usage
+## Module Architecture
 
-Copy `exports/secrets.mixin.tf` to your project by running the following command:
+This module is organized into provider-specific sub-modules to allow consumers to avoid unnecessary provider dependencies:
 
-```sh
-curl -sL https://raw.githubusercontent.com/masterpointio/terraform-secrets-helper/main/exports/secrets.mixin.tf -o secrets.mixin.tf
+```
+terraform-secrets-helper/
+├── modules/
+│   ├── ssm/    # AWS SSM Parameter Store only (requires: hashicorp/aws)
+│   └── sops/   # SOPS encrypted files only (requires: carlpett/sops)
+├── main.tf     # Root module — delegates to both sub-modules (backward compatible)
+└── exports/
+    ├── secrets.ssm.mixin.tf   # SSM-only mixin (no SOPS provider needed)
+    ├── secrets.sops.mixin.tf  # SOPS-only mixin (no AWS provider needed)
+    └── secrets.mixin.tf       # Combined mixin (both SOPS + SSM)
 ```
 
-The mixin incorporates the invocation of this module, so you simply need to configure the required `secret_mapping` variable and then reference it within your code.
+**Choose your entry point based on which secret backends you need:**
 
-See the full example in [examples/complete](https://github.com/masterpointio/terraform-secrets-helper/tree/main/examples/complete)
+| You need  | Mixin                   | Module source                                | SOPS provider required? |
+| --------- | ----------------------- | -------------------------------------------- | ----------------------- |
+| SSM only  | `secrets.ssm.mixin.tf`  | `masterpointio/helper/secrets//modules/ssm`  | No                      |
+| SOPS only | `secrets.sops.mixin.tf` | `masterpointio/helper/secrets//modules/sops` | Yes                     |
+| Both      | `secrets.mixin.tf`      | `masterpointio/helper/secrets` (root module) | Yes                     |
 
-### SOPS Secrets
+## Usage
+
+### SSM-Only
+
+Copy `exports/secrets.ssm.mixin.tf` to your project:
+
+```sh
+curl -sL https://raw.githubusercontent.com/masterpointio/terraform-secrets-helper/main/exports/secrets.ssm.mixin.tf -o secrets.ssm.mixin.tf
+```
+
+This uses the `modules/ssm` sub-module and does **not** require the SOPS provider.
+
+```hcl
+secret_mapping = [{
+  name = "api_token"
+  type = "ssm"
+  path = "/myapp/prod/api_token"
+}]
+```
+
+### SOPS-Only
+
+Copy `exports/secrets.sops.mixin.tf` to your project:
+
+```sh
+curl -sL https://raw.githubusercontent.com/masterpointio/terraform-secrets-helper/main/exports/secrets.sops.mixin.tf -o secrets.sops.mixin.tf
+```
+
+This uses the `modules/sops` sub-module. The SOPS provider (`carlpett/sops`) **is** required.
 
 ```hcl
 secret_mapping = [{
@@ -41,19 +81,15 @@ output "db_password" {
 }
 ```
 
-### AWS SSM Parameter Store Secrets
+### Both (SSM + SOPS)
 
-```hcl
-secret_mapping = [{
-  name = "api_token"
-  type = "ssm"
-  path = "/myapp/prod/api_token"
-}]
+Copy `exports/secrets.mixin.tf` to your project:
+
+```sh
+curl -sL https://raw.githubusercontent.com/masterpointio/terraform-secrets-helper/main/exports/secrets.mixin.tf -o secrets.mixin.tf
 ```
 
-### Mixed Sources
-
-You can combine both SOPS and SSM secrets in the same configuration:
+This uses the root module which supports both backends. Both the SOPS provider (`carlpett/sops`) and the AWS provider (`hashicorp/aws`) are required.
 
 ```hcl
 secret_mapping = [
@@ -70,7 +106,37 @@ secret_mapping = [
 ]
 ```
 
-# Future Enhancements
+### Direct Sub-Module Usage
+
+You can also reference sub-modules directly for maximum control:
+
+```hcl
+module "secrets_ssm" {
+  source  = "masterpointio/helper/secrets//modules/ssm"
+  version = "3.0.0"
+
+  secret_mapping = [
+    { name = "api_token", path = "/myapp/prod/api_token" }
+  ]
+}
+
+module "secrets_sops" {
+  source  = "masterpointio/helper/secrets//modules/sops"
+  version = "3.0.0"
+
+  secret_mapping = [
+    { name = "db_password", file = "secrets.yaml" }
+  ]
+}
+
+locals {
+  secrets = merge(module.secrets_ssm.all, module.secrets_sops.all)
+}
+```
+
+See the full example in [examples/complete](https://github.com/masterpointio/terraform-secrets-helper/tree/main/examples/complete)
+
+## Future Enhancements
 
 The module currently supports SOPS and AWS SSM Parameter Store. Future versions may add support for other secret providers like HashiCorp Vault, AWS Secrets Manager, and more.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This module can be included as a child module, where needed, to fetch secrets an
 
 This module is organized into provider-specific sub-modules to allow consumers to avoid unnecessary provider dependencies:
 
-```
+```sh
 terraform-secrets-helper/
 ├── modules/
 │   ├── ssm/    # AWS SSM Parameter Store only (requires: hashicorp/aws)
@@ -141,7 +141,7 @@ See the full example in [examples/complete](https://github.com/masterpointio/ter
 The module currently supports SOPS and AWS SSM Parameter Store. Future versions may add support for other secret providers like HashiCorp Vault, AWS Secrets Manager, and more.
 
 <!-- prettier-ignore-start -->
-<!-- markdownlint-disable MD013 -->
+<!-- markdownlint-disable MD013 MD060 -->
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -153,21 +153,18 @@ The module currently supports SOPS and AWS SSM Parameter Store. Future versions 
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
-| <a name="provider_sops"></a> [sops](#provider\_sops) | >= 0.7 |
+No providers.
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_sops"></a> [sops](#module\_sops) | ./modules/sops | n/a |
+| <a name="module_ssm"></a> [ssm](#module\_ssm) | ./modules/ssm | n/a |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_ssm_parameter.ssm_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
-| [sops_file.sops_secrets](https://registry.terraform.io/providers/carlpett/sops/latest/docs/data-sources/file) | data source |
+No resources.
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Copy `exports/secrets.mixin.tf` to your project:
 curl -sL https://raw.githubusercontent.com/masterpointio/terraform-secrets-helper/main/exports/secrets.mixin.tf -o secrets.mixin.tf
 ```
 
-This uses the root module which supports both backends. Both the SOPS provider (`carlpett/sops`) and the AWS provider (`hashicorp/aws`) are required.
+This uses the base child module which supports both backends. Both the SOPS provider (`carlpett/sops`) and the AWS provider (`hashicorp/aws`) are required.
 
 ```hcl
 secret_mapping = [

--- a/exports/secrets.sops.mixin.tf
+++ b/exports/secrets.sops.mixin.tf
@@ -1,9 +1,8 @@
 # tflint-ignore-file: terraform_required_version
 
-# COMBINED MIXIN - Uses the root module which supports both SOPS and SSM secrets.
-# Requires the SOPS provider (carlpett/sops) and the AWS provider (hashicorp/aws).
-# If you only need one backend, use secrets.ssm.mixin.tf or secrets.sops.mixin.tf instead
-# to avoid pulling in unnecessary provider dependencies.
+# SOPS-ONLY MIXIN - Uses the SOPS sub-module.
+# Requires the SOPS provider (carlpett/sops).
+# If you also need SSM secrets, use secrets.mixin.tf (both) or secrets.ssm.mixin.tf (SSM only).
 
 locals {
   # tflint-ignore: terraform_unused_declarations
@@ -12,9 +11,17 @@ locals {
 
 module "secrets" {
   # checkov:skip=CKV_TF_1: For now we use Terraform registry source, not git. If switching to git, we should use a commit hash.
-  source         = "masterpointio/helper/secrets"
-  version        = "3.0.0"
-  secret_mapping = var.secret_mapping
+  source  = "masterpointio/helper/secrets//modules/sops"
+  version = "3.0.0"
+
+  secret_mapping = [
+    for mapping in var.secret_mapping :
+    {
+      name = mapping.name
+      file = mapping.file
+    }
+    if mapping.type == "sops"
+  ]
 }
 
 variable "secret_mapping" {
@@ -29,7 +36,7 @@ variable "secret_mapping" {
     The list of secret mappings the application will need.
     This creates secret values for the component to consume at `local.secrets[name]`.
     For SOPS secrets: use type="sops" (default), file="path/to/sops/file.yaml", and name matching a key in the SOPS file.
-    For SSM secrets: use type="ssm" and path="/path/to/ssm/parameter".
+    NOTE: SSM secrets require using secrets.ssm.mixin.tf or secrets.mixin.tf instead.
     EOT
 
   validation {
@@ -46,13 +53,5 @@ variable "secret_mapping" {
       mapping.type == "sops" ? mapping.file != null : true
     ])
     error_message = "SOPS secrets require 'file' attribute."
-  }
-
-  validation {
-    condition = alltrue([
-      for mapping in var.secret_mapping :
-      mapping.type == "ssm" ? mapping.path != null : true
-    ])
-    error_message = "SSM secrets require 'path' attribute."
   }
 }

--- a/exports/secrets.sops.mixin.tf
+++ b/exports/secrets.sops.mixin.tf
@@ -42,9 +42,9 @@ variable "secret_mapping" {
   validation {
     condition = alltrue([
       for mapping in var.secret_mapping :
-      contains(["sops", "ssm"], mapping.type)
+      mapping.type == "sops"
     ])
-    error_message = "Secret type must be either 'sops' or 'ssm'."
+    error_message = "This is a SOPS-only mixin. All secrets must have type=\"sops\". For SSM secrets, use secrets.ssm.mixin.tf or secrets.mixin.tf instead."
   }
 
   validation {

--- a/exports/secrets.ssm.mixin.tf
+++ b/exports/secrets.ssm.mixin.tf
@@ -1,9 +1,8 @@
 # tflint-ignore-file: terraform_required_version
 
-# COMBINED MIXIN - Uses the root module which supports both SOPS and SSM secrets.
-# Requires the SOPS provider (carlpett/sops) and the AWS provider (hashicorp/aws).
-# If you only need one backend, use secrets.ssm.mixin.tf or secrets.sops.mixin.tf instead
-# to avoid pulling in unnecessary provider dependencies.
+# SSM-ONLY MIXIN - Uses the SSM sub-module.
+# The SOPS provider (carlpett/sops) is NOT required.
+# If you also need SOPS secrets, use secrets.mixin.tf (both) or secrets.sops.mixin.tf (SOPS only).
 
 locals {
   # tflint-ignore: terraform_unused_declarations
@@ -12,15 +11,23 @@ locals {
 
 module "secrets" {
   # checkov:skip=CKV_TF_1: For now we use Terraform registry source, not git. If switching to git, we should use a commit hash.
-  source         = "masterpointio/helper/secrets"
-  version        = "3.0.0"
-  secret_mapping = var.secret_mapping
+  source  = "masterpointio/helper/secrets//modules/ssm"
+  version = "3.0.0"
+
+  secret_mapping = [
+    for mapping in var.secret_mapping :
+    {
+      name = mapping.name
+      path = mapping.path
+    }
+    if mapping.type == "ssm"
+  ]
 }
 
 variable "secret_mapping" {
   type = list(object({
     name = string
-    type = optional(string, "sops")
+    type = optional(string, "ssm")
     path = optional(string, null)
     file = optional(string, null)
   }))
@@ -28,8 +35,8 @@ variable "secret_mapping" {
   description = <<-EOT
     The list of secret mappings the application will need.
     This creates secret values for the component to consume at `local.secrets[name]`.
-    For SOPS secrets: use type="sops" (default), file="path/to/sops/file.yaml", and name matching a key in the SOPS file.
-    For SSM secrets: use type="ssm" and path="/path/to/ssm/parameter".
+    For SSM secrets: use type="ssm" (default) and path="/path/to/ssm/parameter".
+    NOTE: SOPS secrets require using secrets.sops.mixin.tf or secrets.mixin.tf instead.
     EOT
 
   validation {
@@ -38,14 +45,6 @@ variable "secret_mapping" {
       contains(["sops", "ssm"], mapping.type)
     ])
     error_message = "Secret type must be either 'sops' or 'ssm'."
-  }
-
-  validation {
-    condition = alltrue([
-      for mapping in var.secret_mapping :
-      mapping.type == "sops" ? mapping.file != null : true
-    ])
-    error_message = "SOPS secrets require 'file' attribute."
   }
 
   validation {

--- a/exports/secrets.ssm.mixin.tf
+++ b/exports/secrets.ssm.mixin.tf
@@ -42,9 +42,9 @@ variable "secret_mapping" {
   validation {
     condition = alltrue([
       for mapping in var.secret_mapping :
-      contains(["sops", "ssm"], mapping.type)
+      mapping.type == "ssm"
     ])
-    error_message = "Secret type must be either 'sops' or 'ssm'."
+    error_message = "This is an SSM-only mixin. All secrets must have type=\"ssm\". For SOPS secrets, use secrets.sops.mixin.tf or secrets.mixin.tf instead."
   }
 
   validation {

--- a/main.tf
+++ b/main.tf
@@ -1,56 +1,29 @@
+module "ssm" {
+  source = "./modules/ssm"
+
+  secret_mapping = [
+    for mapping in var.secret_mapping :
+    {
+      name = mapping.name
+      path = mapping.path
+    }
+    if mapping.type == "ssm"
+  ]
+}
+
+module "sops" {
+  source = "./modules/sops"
+
+  secret_mapping = [
+    for mapping in var.secret_mapping :
+    {
+      name = mapping.name
+      file = mapping.file
+    }
+    if mapping.type == "sops"
+  ]
+}
+
 locals {
-  # Filter out our sops mappings
-  sops_secret_mapping = [
-    for mapping in var.secret_mapping :
-    mapping if mapping.type == "sops"
-  ]
-
-  # Filter the unique set of sops files we need to pull
-  sops_files = toset(distinct([
-    for mapping in local.sops_secret_mapping :
-    mapping.file
-  ]))
-
-  # Collect our sops file values as a map of "sops file path => map of values"
-  sops_yamls = {
-    for sops_file in local.sops_files :
-    sops_file => yamldecode(data.sops_file.sops_secrets[sops_file].raw)
-  }
-
-  # Create our sops secret name to value map
-  sops_secrets = {
-    for mapping in local.sops_secret_mapping :
-    mapping.name => lookup(local.sops_yamls[mapping.file], mapping.name, null)
-  }
-
-  # Filter out our ssm mappings
-  ssm_secret_mapping = [
-    for mapping in var.secret_mapping :
-    mapping if mapping.type == "ssm"
-  ]
-
-  # Collect the ssm paths we need to pull
-  ssm_paths = toset(distinct([
-    for mapping in local.ssm_secret_mapping :
-    mapping.path
-  ]))
-
-  # Create our ssm secret name to value map
-  ssm_secrets = {
-    for mapping in local.ssm_secret_mapping :
-    mapping.name => data.aws_ssm_parameter.ssm_secrets[mapping.path].value
-  }
-
-  # Merge the final ssm secrets + sops secrets for generic consumption in the component.
-  secrets = merge(local.sops_secrets, local.ssm_secrets)
-}
-
-data "sops_file" "sops_secrets" {
-  for_each    = local.sops_files
-  source_file = "${path.root}/${each.value}"
-}
-
-data "aws_ssm_parameter" "ssm_secrets" {
-  for_each = local.ssm_paths
-  name     = each.value
+  secrets = merge(module.sops.all, module.ssm.all)
 }

--- a/modules/sops/main.tf
+++ b/modules/sops/main.tf
@@ -1,0 +1,21 @@
+locals {
+  sops_files = toset(distinct([
+    for mapping in var.secret_mapping :
+    mapping.file
+  ]))
+
+  sops_yamls = {
+    for sops_file in local.sops_files :
+    sops_file => yamldecode(data.sops_file.sops_secrets[sops_file].raw)
+  }
+
+  sops_secrets = {
+    for mapping in var.secret_mapping :
+    mapping.name => lookup(local.sops_yamls[mapping.file], mapping.name, null)
+  }
+}
+
+data "sops_file" "sops_secrets" {
+  for_each    = local.sops_files
+  source_file = "${path.root}/${each.value}"
+}

--- a/modules/sops/main.tf
+++ b/modules/sops/main.tf
@@ -11,7 +11,7 @@ locals {
 
   sops_secrets = {
     for mapping in var.secret_mapping :
-    mapping.name => lookup(local.sops_yamls[mapping.file], mapping.name, null)
+    mapping.name => local.sops_yamls[mapping.file][mapping.name]
   }
 }
 

--- a/modules/sops/outputs.tf
+++ b/modules/sops/outputs.tf
@@ -1,0 +1,5 @@
+output "all" {
+  value       = local.sops_secrets
+  description = "The secrets pulled from SOPS-encrypted files."
+  sensitive   = true
+}

--- a/modules/sops/variables.tf
+++ b/modules/sops/variables.tf
@@ -1,0 +1,14 @@
+variable "secret_mapping" {
+  type = list(object({
+    name = string
+    file = string
+  }))
+  default     = []
+  description = <<-EOT
+    The list of SOPS secret mappings the application will need.
+    This creates secret values for the component to consume at `module.secrets_sops.all["name"]`.
+    Each entry requires:
+      - name: The key used to reference the secret, matching a key in the SOPS YAML file
+      - file: Path to the SOPS-encrypted YAML file relative to the root module
+    EOT
+}

--- a/modules/sops/versions.tf
+++ b/modules/sops/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    sops = {
+      source  = "carlpett/sops"
+      version = ">= 0.7"
+    }
+  }
+}

--- a/modules/ssm/main.tf
+++ b/modules/ssm/main.tf
@@ -1,0 +1,16 @@
+locals {
+  ssm_paths = toset(distinct([
+    for mapping in var.secret_mapping :
+    mapping.path
+  ]))
+
+  ssm_secrets = {
+    for mapping in var.secret_mapping :
+    mapping.name => data.aws_ssm_parameter.ssm_secrets[mapping.path].value
+  }
+}
+
+data "aws_ssm_parameter" "ssm_secrets" {
+  for_each = local.ssm_paths
+  name     = each.value
+}

--- a/modules/ssm/outputs.tf
+++ b/modules/ssm/outputs.tf
@@ -1,0 +1,5 @@
+output "all" {
+  value       = local.ssm_secrets
+  description = "The secrets pulled from AWS SSM Parameter Store."
+  sensitive   = true
+}

--- a/modules/ssm/variables.tf
+++ b/modules/ssm/variables.tf
@@ -1,0 +1,14 @@
+variable "secret_mapping" {
+  type = list(object({
+    name = string
+    path = string
+  }))
+  default     = []
+  description = <<-EOT
+    The list of SSM secret mappings the application will need.
+    This creates secret values for the component to consume at `local.secrets[name]`.
+    Each entry requires:
+      - name: The key used to reference the secret via `module.secrets_ssm.all["name"]`
+      - path: The SSM parameter path, e.g. "/myapp/prod/api_token"
+    EOT
+}

--- a/modules/ssm/versions.tf
+++ b/modules/ssm/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -1,7 +1,7 @@
 mock_provider "sops" {
   mock_data "sops_file" {
     defaults = {
-      raw = "db_password: supersecret123\napi_key: test-api-key-456"
+      raw = "db_password: supersecret123\napi_key: test-api-key-456\nredis_password: redis-secret-789"
     }
   }
 }

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -22,7 +22,7 @@ run "test_empty_secret_mapping" {
   }
 
   assert {
-    condition = length(local.secrets) == 0
+    condition     = length(local.secrets) == 0
     error_message = "Empty input should result in empty final secrets"
   }
 }
@@ -51,40 +51,17 @@ run "test_multiple_files_and_secrets" {
   }
 
   assert {
-    condition = length(local.sops_secret_mapping) == 3
-    error_message = "Should have 3 sops secret mappings"
-  }
-
-  assert {
-    condition = (
-      length(local.sops_files) == 2
-      && contains(local.sops_files, "database.yaml")
-      && contains(local.sops_files, "api.yaml")
-    )
-    error_message = "Should have 2 unique sops files (database.yaml and api.yaml)"
-  }
-
-  assert {
-    condition = length(local.sops_yamls) == 2
-    error_message = "Should have 2 YAML files loaded in sops_yamls"
-  }
-
-  assert {
-    condition = length(local.sops_secrets) == 3
-    error_message = "Should have 3 secrets in sops_secrets map"
+    condition     = length(local.secrets) == 3
+    error_message = "Should have 3 total secrets from SOPS"
   }
 
   assert {
     condition = alltrue([
-      for mapping in local.sops_secret_mapping :
-      contains(keys(local.sops_secrets), mapping.name)
+      contains(keys(local.secrets), "db_password"),
+      contains(keys(local.secrets), "api_key"),
+      contains(keys(local.secrets), "redis_password"),
     ])
-    error_message = "All secret mappings should result in corresponding secret names"
-  }
-
-  assert {
-    condition = length(distinct(keys(local.sops_secrets))) == length(keys(local.sops_secrets))
-    error_message = "All secret keys should be unique"
+    error_message = "All SOPS secret names should be present"
   }
 }
 
@@ -107,27 +84,16 @@ run "test_ssm_secrets" {
   }
 
   assert {
-    condition     = length(local.ssm_secret_mapping) == 2
-    error_message = "Should have 2 SSM secret mappings"
+    condition     = length(local.secrets) == 2
+    error_message = "Should have 2 SSM secrets"
   }
 
   assert {
-    condition = (
-      length(local.ssm_paths) == 2
-      && contains(local.ssm_paths, "/app/secret")
-      && contains(local.ssm_paths, "/app/another_secret")
-    )
-    error_message = "Should have both SSM paths in ssm_paths"
-  }
-
-  assert {
-    condition     = length(local.ssm_secrets) == 2
-    error_message = "Should have 2 secrets in ssm_secrets map"
-  }
-
-  assert {
-    condition     = length(local.sops_secret_mapping) == 0
-    error_message = "Should have no SOPS secret mappings"
+    condition = alltrue([
+      contains(keys(local.secrets), "ssm_secret"),
+      contains(keys(local.secrets), "another_ssm_secret"),
+    ])
+    error_message = "All SSM secret names should be present"
   }
 }
 
@@ -155,26 +121,16 @@ run "test_mixed_sops_and_ssm" {
   }
 
   assert {
-    condition     = length(local.sops_secret_mapping) == 2
-    error_message = "Should have 2 SOPS secret mappings"
-  }
-
-  assert {
-    condition     = length(local.ssm_secret_mapping) == 1
-    error_message = "Should have 1 SSM secret mapping"
-  }
-
-  assert {
     condition     = length(local.secrets) == 3
     error_message = "Should have 3 total secrets"
   }
 
   assert {
-    condition = (
-      contains(keys(local.secrets), "db_password")
-      && contains(keys(local.secrets), "api_token")
-      && contains(keys(local.secrets), "api_key")
-    )
+    condition = alltrue([
+      contains(keys(local.secrets), "db_password"),
+      contains(keys(local.secrets), "api_token"),
+      contains(keys(local.secrets), "api_key"),
+    ])
     error_message = "All secret names should be present in the merged secrets"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_version = ">= 1.3"
 
   # Providers are used by sub-modules (modules/ssm, modules/sops) and declared
-  # here so consumers of the root module know the full set of provider dependencies.
+  # here so consumers of the base child module know the full set of provider dependencies.
   required_providers {
     sops = {
       source  = "carlpett/sops"

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,10 @@
+# tflint-ignore-file: terraform_unused_required_providers
+
 terraform {
   required_version = ">= 1.3"
 
+  # Providers are used by sub-modules (modules/ssm, modules/sops) and declared
+  # here so consumers of the root module know the full set of provider dependencies.
   required_providers {
     sops = {
       source  = "carlpett/sops"

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     sops = {
       source  = "carlpett/sops"
-      version = "1.3.0"
+      version = ">= 0.7"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
## what

- Splits the monolithic module into `modules/ssm` (AWS-only) and `modules/sops` (SOPS-only) sub-modules so consumers can reference only the backend they need, avoiding unnecessary provider downloads during `init`
- Adds three export mixins following the `secrets.<backend>.mixin.tf` naming pattern: `secrets.ssm.mixin.tf`, `secrets.sops.mixin.tf`, and `secrets.mixin.tf` (combined)
- Root module is refactored to delegate to sub-modules internally - fully backward compatible for existing consumers using `masterpointio/helper/secrets`.

## why

- The module unconditionally declares `carlpett/sops` in `required_providers`. Terraform/OpenTofu resolves all provider requirements at `init` time via static analysis  before evaluating any expressions like `for_each`. This means even when no SOPS secrets are configured (e.g. SSM-only consumers), the SOPS provider must still be downloadable, causing `init` failures in environments where it isn't available.
- HCL does not support conditional `required_providers`, and `for_each = []` or `count = 0` on modules/resources does not prevent provider installation. The only way to avoid a provider dependency is to have zero references to it in the loaded configuration.

## references

- https://www.notion.so/masterpoint/SPIKE-Investigate-dynamic-removal-of-unused-providers-from-secrets-helper-module-317859758a56818aa572ff795e8fc340?source=copy_link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced modular architecture enabling independent configuration of AWS Parameter Store and SOPS-based secret backends with flexible mapping options.

* **Documentation**
  * Enhanced guides with updated architecture details and expanded usage examples for different secret management configurations.

* **Chores**
  * Updated dependencies: trunk plugin, renovate linter, markdownlint, and trivy scanner to latest patch versions.

* **Tests**
  * Refined test coverage to validate consolidated secrets validation across integrated backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->