### PR TITLE
fix: pin SOPS at 1.3.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     sops = {
       source  = "carlpett/sops"
-      version = ">= 0.7"
+      version = "1.3.0"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
The provider is being flaky.

Trying to pull from 1.4.0, but it's not released yet: 
<img width="1564" height="670" alt="image" src="https://github.com/user-attachments/assets/de15be1a-bf6c-4010-bd6d-1a97539dc90f" />
<img width="2418" height="903" alt="image" src="https://github.com/user-attachments/assets/6d3327c1-6d01-420c-b3eb-fe036d5bb868" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated provider version requirement to 1.3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->